### PR TITLE
Remove gson

### DIFF
--- a/Encoder/src/main/java/com/timmattison/hacking/usbrubberducky/instructions/KeypressInstruction.java
+++ b/Encoder/src/main/java/com/timmattison/hacking/usbrubberducky/instructions/KeypressInstruction.java
@@ -1,6 +1,5 @@
 package com.timmattison.hacking.usbrubberducky.instructions;
 
-import com.google.gson.Gson;
 import com.google.inject.assistedinject.Assisted;
 import com.timmattison.hacking.usbrubberducky.exceptions.DuplicateKeyboardCodeException;
 import com.timmattison.hacking.usbrubberducky.exceptions.ModifierCollisionException;
@@ -96,6 +95,6 @@ public class KeypressInstruction implements Instruction {
 
     @Override
     public String toString() {
-        return new Gson().toJson(this);
+        throw new UnsupportedOperationException("Not implemented");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,6 @@
             <version>2.4</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>17.0</version>
-        </dependency>
-        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,6 @@
             <version>17.0</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.2.4</version>
-        </dependency>
-        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
             <groupId>ru.concerteza.buildnumber</groupId>
             <artifactId>maven-jgit-buildnumber-plugin</artifactId>
             <version>1.2.9</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
I just wanted to remove Gson, but then I saw Guava was in there and that maven-jgit-buildnumber-plugin was getting included with its dependencies as well.  These tweaks reduce the JAR size from `7302194` bytes to `1073219` bytes on my system which is an 85% reduction in size!